### PR TITLE
jaraco.functools 4.1.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
     - jaraco.classes
   commands:
     - pip check
-    - pytest -vv test_functools.py
+    - pytest -vv test_functools.py -k "not test_function_throttled"
 
 about:
   home: https://github.com/jaraco/jaraco.functools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,18 @@
 {% set name = "jaraco.functools" %}
-{% set version = "3.3.0" %}
+{% set version = "4.1.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: bfcf7da71e2a0e980189b0744b59dba6c1dcf66dcd7a30f8a4413e478046b314
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/jaraco_functools-{{ version }}.tar.gz
+  sha256: 70f7e0e2ae076498e212562325e805204fc092d7b4c17e0e86c959e249701a9d
 
 build:
-  noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: True  # [py<38]
 
 requirements:
   host:
@@ -20,13 +20,24 @@ requirements:
     - pip
     - setuptools_scm >=3.4.1
     - toml
+    - wheel
+    - setuptools
   run:
     - python
     - more-itertools
 
 test:
+  source_files:
+    - test_functools.py
   imports:
     - jaraco.functools
+  requires:
+    - pip
+    - pytest
+    - jaraco.classes
+  commands:
+    - pip check
+    - pytest -vv test_functools.py
 
 about:
   home: https://github.com/jaraco/jaraco.functools


### PR DESCRIPTION
jaraco.functools 4.1.0 

**Destination channel:** Defaults

### Links

- [PKG-6983]
- dev_url:        https://github.com/jaraco/jaraco.functools/tree/v4.1.0
- conda_forge:    https://github.com/conda-forge/jaraco.functools-feedstock
- pypi:           https://pypi.org/project/jaraco.functools/4.1.0
- pypi inspector: https://inspector.pypi.io/project/jaraco.functools/4.1.0

### Explanation of changes:

- new version number


[PKG-6983]: https://anaconda.atlassian.net/browse/PKG-6983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ